### PR TITLE
Make SubChannelReceiver::recv fairer under contention

### DIFF
--- a/src/mux/mod.rs
+++ b/src/mux/mod.rs
@@ -847,85 +847,67 @@ impl MultiReceiver {
     }
 
     #[instrument(level = "debug", err(level = "debug"))]
-    fn recv(mr: &Arc<MultiReceiver>) -> Result<(), MuxError> {
-        let msg = loop {
-            let polling_interval = Duration::new(1, 0);
-            // The following is inlined to avoid deadlock.
-            let maybe_mrs = mr
-                .mutator
-                .lock()
-                .as_ref()
-                .unwrap()
-                .ipc_receiver_or_multi_receiver_set
-                .multi_receiver_set();
-            if maybe_mrs.is_some() {
-                return Err(MuxError::InternalError("SubReceiver sharing an IPC channel with another SubReceiver in a SubReceiverSet cannot receive".to_string()));
+    fn try_recv(mr: &Arc<MultiReceiver>) -> Result<(), TryRecvError> {
+        // The following is inlined to avoid deadlock.
+        let maybe_mrs = mr
+            .mutator
+            .lock()
+            .as_ref()
+            .unwrap()
+            .ipc_receiver_or_multi_receiver_set
+            .multi_receiver_set();
+        if let Some(multi_receiver_set) = maybe_mrs {
+            match MultiReceiverSet::try_select(&multi_receiver_set) {
+                Ok(_) => return Ok(()),
+                Err(e) => return Err(e),
             }
-            let result = mr
-                .mutator
-                .lock()
-                .as_ref()
-                .unwrap()
-                .ipc_receiver_or_multi_receiver_set
-                .try_recv_timeout(polling_interval);
-            match result {
-                Ok(msg) => break Ok(msg),
-                Err(TryRecvError::Empty) => {
-                    if mr.poll() {
-                        // At least one probe failed, so return to caller.
-                        return Ok(());
-                    }
-                },
-                Err(TryRecvError::Handled) => {
-                    return Ok(());
-                },
-                Err(TryRecvError::MuxError(e)) => {
-                    break Err(e);
-                },
-            }
-        }?;
-        Self::handle(Arc::clone(mr), msg)
+        }
+        let result = mr
+            .mutator
+            .lock()
+            .as_ref()
+            .unwrap()
+            .ipc_receiver_or_multi_receiver_set
+            .try_recv();
+        match result {
+            Ok(msg) => {
+                Self::handle(Arc::clone(mr), msg).map_err(TryRecvError::MuxError)?;
+                Err(TryRecvError::Handled)
+            },
+            Err(TryRecvError::Handled) => Ok(()),
+            Err(e) => Err(e),
+        }
     }
 
     #[instrument(level = "debug", err(level = "debug"))]
-    fn try_recv(mr: &Arc<MultiReceiver>) -> Result<(), TryRecvError> {
-        let msg = {
-            // The following is inlined to avoid deadlock.
-            let maybe_mrs = mr
-                .mutator
-                .lock()
-                .as_ref()
-                .unwrap()
-                .ipc_receiver_or_multi_receiver_set
-                .multi_receiver_set();
-            if let Some(multi_receiver_set) = maybe_mrs {
-                match MultiReceiverSet::try_select(&multi_receiver_set) {
-                    Ok(_) => return Ok(()),
-                    Err(e) => return Err(e),
-                }
-            }
-            let result = mr
-                .mutator
-                .lock()
-                .as_ref()
-                .unwrap()
-                .ipc_receiver_or_multi_receiver_set
-                .try_recv();
-            match result {
-                Ok(msg) => msg,
-                Err(TryRecvError::Empty) => {
-                    return Err(TryRecvError::Empty);
-                },
-                Err(TryRecvError::Handled) => {
-                    return Ok(());
-                },
-                Err(e) => {
-                    return Err(e);
-                },
-            }
-        };
-        Self::handle(Arc::clone(mr), msg).map_err(TryRecvError::MuxError)?;
-        Err(TryRecvError::Handled)
+    fn try_recv_timeout(mr: &Arc<MultiReceiver>, duration: Duration) -> Result<(), TryRecvError> {
+        // The following is inlined to avoid deadlock.
+        let maybe_mrs = mr
+            .mutator
+            .lock()
+            .as_ref()
+            .unwrap()
+            .ipc_receiver_or_multi_receiver_set
+            .multi_receiver_set();
+        if maybe_mrs.is_some() {
+            return Err(TryRecvError::MuxError(MuxError::InternalError("SubReceiver sharing an IPC channel with another SubReceiver in a SubReceiverSet cannot receive".to_string())));
+        }
+        let result = mr
+            .mutator
+            .lock()
+            .as_ref()
+            .unwrap()
+            .ipc_receiver_or_multi_receiver_set
+            .try_recv_timeout(duration);
+        match result {
+            Ok(msg) => Self::handle(Arc::clone(mr), msg).map_err(TryRecvError::MuxError),
+            Err(TryRecvError::Empty) => {
+                mr.poll();
+                Ok(())
+            },
+            Err(TryRecvError::Handled) => Ok(()),
+            Err(e) => Err(e),
+        }
     }
 
     #[instrument(level = "debug")]
@@ -1032,7 +1014,9 @@ impl MultiReceiver {
                             ipc_sender.err().unwrap()
                         );
                         sm.to_be_sent(via, Box::new(|| false));
-                        sm.receive_failed(via);
+                        if let Some(sender) = sm.receive_failed(via) {
+                            let _ = sender.send(ResolvedMessageOrDisconnect::Disconnect(scid));
+                        }
                     }
                 }
 
@@ -1040,7 +1024,9 @@ impl MultiReceiver {
             },
             MultiMessage::ReceiveFailed { scid, via } => {
                 if let Some(sm) = mr.mutator.lock().unwrap().sub_channels.get(&scid) {
-                    sm.receive_failed(via);
+                    if let Some(sender) = sm.receive_failed(via) {
+                        let _ = sender.send(ResolvedMessageOrDisconnect::Disconnect(scid));
+                    }
                 }
 
                 Ok(())
@@ -1560,6 +1546,7 @@ impl SubChannelReceiver {
     where
         T: for<'de> Deserialize<'de> + Serialize,
     {
+        let polling_interval = Duration::new(1, 0);
         loop {
             match self.channel.try_recv() {
                 Ok(ResolvedMessageOrDisconnect::ResolvedMessage(ResolvedMessage {
@@ -1580,12 +1567,18 @@ impl SubChannelReceiver {
                 },
                 Err(mpsc::TryRecvError::Empty) => {
                     // receive another message, possibly for another subchannel
-                    let multi_receiver_result = MultiReceiver::recv(&self.multi_receiver);
+                    let multi_receiver_result =
+                        MultiReceiver::try_recv_timeout(&self.multi_receiver, polling_interval);
                     log::trace!(
                         "SubChannelReceiver::recv multi_receiver_result = {:#?}",
                         multi_receiver_result.as_ref()
                     );
-                    multi_receiver_result?;
+                    match multi_receiver_result {
+                        Ok(_) => {},
+                        Err(TryRecvError::Empty) => {},
+                        Err(TryRecvError::Handled) => {},
+                        Err(TryRecvError::MuxError(e)) => return Err(e),
+                    }
                 },
                 _ => {
                     return Err(MuxError::Disconnected);

--- a/src/mux/subchannel_lifecycle.rs
+++ b/src/mux/subchannel_lifecycle.rs
@@ -159,10 +159,12 @@ where
 
     // Remove the given inflight value and disconnect it.
     #[instrument(level = "debug", skip(self))]
-    pub fn receive_failed(&self, via: Via) {
+    pub fn receive_failed(&self, via: Via) -> Option<T> {
         self.in_flight.lock().unwrap().remove(&via);
         if self.sources.lock().unwrap().is_empty() && self.in_flight.lock().unwrap().is_empty() {
-            self.maybe.lock().unwrap().take();
+            self.maybe.lock().unwrap().take()
+        } else {
+            None
         }
     }
 

--- a/tests/mux_router_integration_test.rs
+++ b/tests/mux_router_integration_test.rs
@@ -8,60 +8,12 @@
 // except according to those terms.
 
 use ipc_channel_mux::mux::subchannel_router::{ROUTER, RouterProxy};
-use ipc_channel_mux::mux::{Channel, MuxError, SubOneShotServer, SubReceiver, SubSender};
+use ipc_channel_mux::mux::{SubOneShotServer, SubReceiver, SubSender};
 use std::{env, process};
 use test_log::test;
 
 // The integration tests may be run on their own by issuing:
 // cargo test --test '*'
-
-/// Test non-router polling behaviour when a SubSender is sent to a
-/// process which terminates before the SubSender has been
-/// received.
-///
-/// This provides the basis for testing the router behaviour.
-#[test]
-fn subsender_drop_inflight() {
-    let executable_path: String = env!("CARGO_BIN_EXE_crashing_receiving_process").to_string();
-
-    type ChannelPair = (SubSender<SubSender<bool>>, SubSender<()>);
-
-    let (server, token) =
-        SubOneShotServer::<ChannelPair>::new().expect("Failed to create sub one-shot server");
-
-    let mut command = process::Command::new(executable_path);
-    let child_process = command.arg(token);
-
-    let mut child = child_process
-        .spawn()
-        .expect("Failed to start child process");
-
-    let (_rx, (data, control)): (SubReceiver<ChannelPair>, ChannelPair) =
-        server.accept().expect("accept failed");
-
-    let d = Channel::new().unwrap();
-    let (transmit_tx, transmit_rx) = d.sub_channel();
-
-    data.send(transmit_tx).expect("subsender send failed");
-
-    // Ensure that the "sending" message is received so that polling occurs.
-    let (extra_tx, extra_rx) = d.sub_channel();
-    extra_tx.send(()).unwrap();
-    extra_rx.recv().unwrap(); // uses the same IpcReceiver as transmit_rx
-
-    control.send(()).expect("control send failed");
-    let result = child.wait().expect("wait for child process failed");
-    assert_eq!(
-        result.code().unwrap(),
-        1,
-        "child process did not terminate with exit status code 1"
-    );
-
-    match transmit_rx.recv() {
-        Err(MuxError::Disconnected) => {},
-        result => panic!("unexpected result {:?}", result),
-    }
-}
 
 /// Test router behaviour when a SubSender is sent to a
 /// process which terminates before the SubSender has been

--- a/tests/subsender_drop_inflight_integration_test.rs
+++ b/tests/subsender_drop_inflight_integration_test.rs
@@ -1,0 +1,116 @@
+// Copyright 2026 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use ipc_channel_mux::mux::{Channel, MuxError, SubOneShotServer, SubReceiver, SubSender};
+use std::{env, process, thread, time::Duration};
+use test_log::test;
+
+// The integration tests may be run on their own by issuing:
+// cargo test --test '*'
+
+/// Test polling behaviour when a SubSender is sent to a
+/// process which terminates before the SubSender has been
+/// received.
+#[test]
+fn subsender_drop_inflight() {
+    let executable_path: String = env!("CARGO_BIN_EXE_crashing_receiving_process").to_string();
+
+    type ChannelPair = (SubSender<SubSender<bool>>, SubSender<()>);
+
+    let (server, token) =
+        SubOneShotServer::<ChannelPair>::new().expect("Failed to create sub one-shot server");
+
+    let mut command = process::Command::new(executable_path);
+    let child_process = command.arg(token);
+
+    let mut child = child_process
+        .spawn()
+        .expect("Failed to start child process");
+
+    let (_rx, (data, control)): (SubReceiver<ChannelPair>, ChannelPair) =
+        server.accept().expect("accept failed");
+
+    let d = Channel::new().unwrap();
+    let (transmit_tx, transmit_rx) = d.sub_channel();
+
+    data.send(transmit_tx).expect("subsender send failed");
+
+    // Ensure that the "sending" message is received so that polling occurs.
+    let (extra_tx, extra_rx) = d.sub_channel();
+    extra_tx.send(()).unwrap();
+    extra_rx.recv().unwrap(); // uses the same IpcReceiver as transmit_rx
+
+    control.send(()).expect("control send failed");
+    let result = child.wait().expect("wait for child process failed");
+    assert_eq!(
+        result.code().unwrap(),
+        1,
+        "child process did not terminate with exit status code 1"
+    );
+
+    match transmit_rx.recv() {
+        Err(MuxError::Disconnected) => {},
+        result => panic!("unexpected result {:?}", result),
+    }
+}
+
+/// Test polling behaviour when a SubSender is sent to a
+/// process which terminates before the SubSender has been
+/// received and all this racing with a receive on the
+/// SubReceiver corresponding to the transmitted SubSender.
+#[test]
+fn subsender_drop_inflight_subreceiver_receiving() {
+    let executable_path: String = env!("CARGO_BIN_EXE_crashing_receiving_process").to_string();
+
+    type ChannelPair = (SubSender<SubSender<bool>>, SubSender<()>);
+
+    let (server, token) =
+        SubOneShotServer::<ChannelPair>::new().expect("Failed to create sub one-shot server");
+
+    let mut command = process::Command::new(executable_path);
+    let child_process = command.arg(token);
+
+    let mut child = child_process
+        .spawn()
+        .expect("Failed to start child process");
+
+    let (_rx, (data, control)): (SubReceiver<ChannelPair>, ChannelPair) =
+        server.accept().expect("accept failed");
+
+    let d = Channel::new().unwrap();
+    let (transmit_tx, transmit_rx) = d.sub_channel();
+
+    let join_handle = thread::spawn(move || match transmit_rx.recv() {
+        Err(MuxError::Disconnected) => 42,
+        result => panic!("unexpected result {:?}", result),
+    });
+
+    // Give the spawned thread time to block. Although this isn't guaranteed,
+    // it's more likely than not.
+    thread::yield_now();
+    thread::sleep(Duration::from_millis(1000));
+
+    data.send(transmit_tx).expect("subsender send failed");
+
+    // Ensure that the "sending" message is received so that polling occurs.
+    let (extra_tx, extra_rx) = d.sub_channel();
+    extra_tx.send(()).unwrap();
+    extra_rx.recv().unwrap(); // uses the same IpcReceiver as transmit_rx
+
+    control.send(()).expect("control send failed");
+    let result = child.wait().expect("wait for child process failed");
+    assert_eq!(
+        result.code().unwrap(),
+        1,
+        "child process did not terminate with exit status code 1"
+    );
+
+    let result = join_handle.join();
+    assert_eq!(result.unwrap(), 42);
+}


### PR DESCRIPTION
Rework subsending drop integration tests.

subsender_drop_inflight_subreceiver_receiving was prone to hanging because of a lack of fairness when more than one subreceiver with the same underlying IPC channel was attempting to receive at the same time.

To make this fairer, MultiReceiver::recv, refactored to try_recv_timeout, returns to the caller, instead of looping, to ensure that the local channel is checked regularly. When another thread has received the message that the current thread is waiting for, this ensures that the current thread eventually receives the message.